### PR TITLE
Команда Nuxt не рекомендует использовать для параметров конфигурации конструкцию

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -11,7 +11,9 @@ import imagesConfig from './src/app/nuxt-config/image';
 import svgoConfig from './src/app/nuxt-config/svgo';
 
 export default defineNuxtConfig({
-  devtools: { enabled: process.env.NODE_ENV !== 'production' },
+  devtools: {
+    enabled: true,
+  },
   srcDir: 'src/',
   dir: {
     public: 'app/public',
@@ -72,5 +74,19 @@ export default defineNuxtConfig({
         },
       },
     },
+  },
+
+  $production: {
+    devtools: {
+      enabled: false,
+    },
+    modules: [
+      ['@nuxtjs/eslint-module', {
+        failOnError: false,
+      }],
+      ['@nuxtjs/stylelint-module', {
+        failOnError: false,
+      }],
+    ],
   },
 });

--- a/src/app/nuxt-config/eslint.ts
+++ b/src/app/nuxt-config/eslint.ts
@@ -1,6 +1,6 @@
 // https://nuxt.com/modules/eslint#options
 export default {
-  failOnError: process.env.NODE_ENV !== 'production',
+  failOnError: true,
   lintOnStart: false,
   fix: true,
   cache: false,

--- a/src/app/nuxt-config/stylelint.ts
+++ b/src/app/nuxt-config/stylelint.ts
@@ -1,6 +1,6 @@
 // https://nuxt.com/modules/stylelint#options
 export default {
-  failOnError: process.env.NODE_ENV !== 'production',
+  failOnError: true,
   lintOnStart: false,
   fix: true,
   cache: false,


### PR DESCRIPTION
### Описание
Nuxt не рекомендует использовать конструкцию определения параметров конфигурации на основе .env переменных. Например, для определения заголовка страницы не рекомендуется использовать такую конструкцию:
```
export default defineNuxtConfig({
  app: {
    head: {
      title: process.env.NODE_ENV === 'development' ? 'My App (Dev)' : 'My App'
    }
  }
}) 
```
Документация Nuxt нам говорит, что для режима дев разработки переопределить заголовок:
```
export default defineNuxtConfig({
  app: {
    head: {
      title: 'My App'
    }
  },
  $development: {
    app: {
      head: {
        title: 'My App (Dev)'
      }
    }
  }
})
```
Нашел это в [рассылке](https://weekly-vue.news/issues/140). [Ссылка на документацию](https://nuxt.com/docs/getting-started/configuration#environment-overrides) Nuxt

### Функциональные изменения
- В `nuxt.config.ts` по умолчанию определены параметры для режима разработки
- В `nuxt.config.ts` добавлено поле `$production` для переопределения параметров для продакшен режима